### PR TITLE
Feature 19 api host port

### DIFF
--- a/yubipi.py
+++ b/yubipi.py
@@ -343,7 +343,7 @@ def main():
             api.add_resource(OTP, '/',
                              resource_class_kwargs={'yubikey': yubikey})
             app.config['AUTH_TOKENS'] = args.tokens if args.tokens else []
-            app.run(debug=False)
+            app.run(debug=False, host=args.host, port=args.port)
         finally:
             finalize_gpio()
     else:


### PR DESCRIPTION
Added arguments `-H/--host` and `-P/--port` to configure the API host and port, and integrated them in the Flask run call. Also renamed `-P/--press-duration` to `-S/--press-duration` to avoid the conflict.