### PR TITLE
Bugfix 35 authless server

### DIFF
--- a/yubipi.py
+++ b/yubipi.py
@@ -510,7 +510,8 @@ def authenticated(function):
     This decorator takes the X-Auth-Token header and checks its presence in the
     AUTH_TOKENS variable of the Flask app configuration. It returns the
     actual endpoint function when the authentication was successful or returns
-    an unauthorized HTTP code.
+    an unauthorized HTTP code. If there is nothing given in AUTH_TOKENS it will
+    just return endpoint.
 
     Parameters
     ----------


### PR DESCRIPTION
Fixed authless bug in authenticated decorator. Now it first checks if there is even any token given, and otherwise returns the endpoint. Also altered the docstring accordingly.

Fixes #35.